### PR TITLE
Tokenizer refactor

### DIFF
--- a/lib/dependencygraph/graph.go
+++ b/lib/dependencygraph/graph.go
@@ -164,8 +164,8 @@ func (graph *DependencyGraph) readImports(filepath string, wg *sync.WaitGroup) {
 	if err != nil {
 		fmt.Printf("WARN: Failed to read file from path %s.\nReceived error: %s\n Skipping...\n", filepath, err)
 	}
-	imports := tk.TokenizeImports()
-	graph.edgeList.Store(filepath, imports)
+	tokenizedFile := tk.TokenizeImports()
+	graph.edgeList.Store(filepath, tokenizedFile.ImportStrings())
 }
 
 // Note: this exists to make testing easier and will likely be removed in the future
@@ -176,8 +176,9 @@ func (graph *DependencyGraph) readImportsSync(filepath string) {
 	if err != nil {
 		fmt.Printf("WARN: Failed to read file from path %s.\nReceived error: %s\n Skipping...\n", filepath, err)
 	}
-	imports := tk.TokenizeImports()
-	graph.edgeList.Store(filepath, imports)
+	tokenizedFile := tk.TokenizeImports()
+	// TODO: rewrite graph to use FileTokens
+	graph.edgeList.Store(filepath, tokenizedFile.ImportStrings())
 }
 
 // TODO: Optimize

--- a/lib/dependencygraph/graph_test.go
+++ b/lib/dependencygraph/graph_test.go
@@ -1,6 +1,9 @@
 package dependencygraph
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestWalk(t *testing.T) {
 	expected_tree := map[string][]string{
@@ -34,6 +37,10 @@ func TestWalk(t *testing.T) {
 			t.Fatalf("Wrong number of items in adjaceny list for %q. Got %d. Expected %d\n", k, len(v), len(expected))
 		}
 
+		// Now that tokenized imports are returned in a map the ordering is non-deterministic
+		// This test should be rewritten when dependencygraph is rewritten to use FileTokens
+		slices.Sort(expected)
+		slices.Sort(v)
 		for i, p := range v {
 			if expected[i] != p {
 				t.Errorf("Expected import path at index %d to be %q. Got %q\n", i, expected[i], p)

--- a/lib/tokenizer/README.md
+++ b/lib/tokenizer/README.md
@@ -55,7 +55,6 @@ I am not tracking common js exports for now since I only track exports to correc
 The export cases I'm currently considering are:
 
 ```js
-export foo;
 export const foo = [...etc];
 export { foo, bar, baz };
 export default etc;

--- a/lib/tokenizer/README.md
+++ b/lib/tokenizer/README.md
@@ -1,0 +1,108 @@
+# Overview
+
+This package converts JavaScript (or related) into tokens that can be used to build a dependency graph.
+
+## How it works
+
+The tokenizer reads each character one at a time and finds:
+
+- imported paths
+- re-exported paths
+- imported tokens
+- exported tokens
+
+Imported identifiers need to be associated with their paths, so they are grouped in an `importToken` struct:
+
+```go
+type importToken struct {
+	importPath          string
+	importedIdentifiers []string
+}
+```
+
+This makes the type for file token:
+
+```go
+type fileToken struct {
+	filePath  string
+	imports   []importToken
+  reExports []string
+	exports   []string
+}
+```
+
+### Finding imports
+
+For dynamic imports and require statements I am only tracking the import paths because, at least for my current use case, that is sufficient.
+
+For esmodule imports:
+
+- Every identifier between the keyword `import` and the keyword `from` is an identifier
+- The first string after `import` is the import path
+- Ignore identifiers after keyword `as`
+- Identifiers are separated by stop characters which are:
+  - Whitespace
+  - Commas
+  - Curly Braces
+  - Slash (i.e. comment starts)
+
+The tokenizer assumes that it is being given valid JavaScript syntax. Syntax errrors may cause issues with tokenization. I have no plans to address this unless it can be done in a way that doesn't degrade performance.
+
+### Exports
+
+I am not tracking common js exports for now since I only track exports to correctly route re-exports. I don't think you can re-export in common js and I am generally assuming that people are not mixing es exports and common js require statements in a way where they are re-exporting from a common js file. I am also assuming dynamic imports are not re-exported.
+
+The export cases I'm currently considering are:
+
+```js
+export foo;
+export const foo = [...etc];
+export { foo, bar, baz };
+export default etc;
+```
+
+For the default export case, we just store "default" as the identifier since it can have an arbitrary name when imported.
+
+For the other cases, we can store all non-keyword identifiers up to `=` or `;`.
+
+We also need to deal with re-exports:
+
+```js
+export { foo, bar, baz } from "./foo";
+```
+
+Here, we need to make sure we don't treat the re-exports as exports since they are just being forwarded from another file. When we run into the `from` token, then the exported identifiers should be ignored and the follwing path should be saved to `reExports`.
+
+### Re-exports
+
+Since these are always preceded by the `export` token, we can handle them in the same method that handles exports. If we run into the `from` token, then we will search for the next string and use that as the re-export path.
+
+#### Re-export identifiers
+
+We could potentially store these in the future I am choosing to treat all `export ... from 'file';` statements as if they were `export * from 'file';`. Since files track their own exports, storing a file path is sufficient to find the related exports. Since I don't currently need anything more granular than which files import from which other files I have decided it is not worth storing this information two places.
+
+## Why a tokenizer?
+
+I first tried to find imports using reglar expressions. Finding a standard import / re-export is pretty simple since we're just looking for anything between `from <quote-char>` and `<quote-char>`. But the ability to put comments in nasty places makes this much harder to solve with regex, and Go's lack of support for lookbehind doesn't help make this easier and since lookbehind is not supported due to performance concerns, I didn't think it made sense to look for a library to handle this.
+
+If this was the only issue, I'd probably be content to let:
+
+```js
+import foo from /* "fake-import" */ "real-import";
+```
+
+remain a bug since I don't think people generally do this, or at the very least it's a use-case I care a lot about.
+
+The main challenge is that esmodules allow you to re-export without using `import`. Re-exporting is pretty nasty because you can re-export from multiple files, wildcard re-export, and then import those from a directory if they are in a file called `index.(js|ts|jsx...)`. Unfortunately, I work with code that does this:
+
+```js
+// foo.js
+import { bar, baz } from "./utils";
+
+// utils/index.js
+export * from "./pathUtils";
+export * from "./fileUtils";
+export * from "./miscUtils";
+```
+
+Which means that I can't solve the problem of where `foo.js` is _really_ being imported from without some information about what is being exported in each file. I'd like to process this all in one pass if possible, so I've chosen to write a tokenizer for this purpose.

--- a/lib/tokenizer/testfiles/nested/index.js
+++ b/lib/tokenizer/testfiles/nested/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+
+export { default as func } from "./test";
+export * from "./test2";
+
+export const IndexComponent = () => {};

--- a/lib/tokenizer/testfiles/nested/test.js
+++ b/lib/tokenizer/testfiles/nested/test.js
@@ -32,3 +32,5 @@ let x = 5;
 x += def;
 console.log('none of this will work!!!');
 fs.readFileSync('./irrelevant/path');
+
+export default func;

--- a/lib/tokenizer/testfiles/nested/test2.js
+++ b/lib/tokenizer/testfiles/nested/test2.js
@@ -1,3 +1,5 @@
+import defaultExample, { example } from "example";
+
 const foo = "foo";
 const bar = "bar";
 const baz = "baz";

--- a/lib/tokenizer/testfiles/nested/test2.js
+++ b/lib/tokenizer/testfiles/nested/test2.js
@@ -1,0 +1,7 @@
+const foo = "foo";
+const bar = "bar";
+const baz = "baz";
+
+export const five = 5;
+export { foo, bar, baz };
+export default function noop() {}

--- a/lib/tokenizer/testfiles/nested/test_idents.js
+++ b/lib/tokenizer/testfiles/nested/test_idents.js
@@ -1,0 +1,8 @@
+import d, { a, b, c } from "../foo";
+import { item as alias } from "./bar";
+import {
+  ident, // rudeComment
+  /* rudeComment */ bar as /* rudeComment */ baz,
+} from "./baz";
+
+await import("just-the-path");

--- a/lib/tokenizer/token.go
+++ b/lib/tokenizer/token.go
@@ -1,22 +1,19 @@
 package tokenizer
 
-type ImportToken struct {
-	ImportPath          string
-	ImportedIdentifiers []string
-}
-
 type FileToken struct {
 	FilePath  string
-	Imports   []ImportToken
+	Imports   map[string][]string
 	ReExports []string
 	Exports   []string
 }
 
 // Utilties for testing
 func (f *FileToken) ImportStrings() []string {
-	var importStrings []string
-	for _, imp := range f.Imports {
-		importStrings = append(importStrings, imp.ImportPath)
+	importStrings := make([]string, len(f.Imports))
+	i := 0
+	for pth := range f.Imports {
+		importStrings[i] = pth
+		i++
 	}
 	return importStrings
 }

--- a/lib/tokenizer/token.go
+++ b/lib/tokenizer/token.go
@@ -1,0 +1,22 @@
+package tokenizer
+
+type ImportToken struct {
+	ImportPath          string
+	ImportedIdentifiers []string
+}
+
+type FileToken struct {
+	FilePath  string
+	Imports   []ImportToken
+	ReExports []string
+	Exports   []string
+}
+
+// Utilties for testing
+func (f *FileToken) ImportStrings() []string {
+	var importStrings []string
+	for _, imp := range f.Imports {
+		importStrings = append(importStrings, imp.ImportPath)
+	}
+	return importStrings
+}

--- a/lib/tokenizer/tokenizer.go
+++ b/lib/tokenizer/tokenizer.go
@@ -20,7 +20,7 @@ const (
 type Tokenizer struct {
 	currentIndex int
 	fileRunes    []rune
-	imports      []ImportToken
+	imports      map[string][]string
 	reExports    []string
 	exports      []string
 	callDir      string
@@ -39,7 +39,7 @@ func New(fileString, callDir string) *Tokenizer {
 	t := Tokenizer{
 		currentIndex: 0,
 		fileRunes:    []rune(fileString),
-		imports:      []ImportToken{},
+		imports:      make(map[string][]string, 0),
 		reExports:    []string{},
 		exports:      []string{},
 		callDir:      callDir,
@@ -167,7 +167,7 @@ func (t *Tokenizer) readImportString() {
 	if isRelativePath(path) {
 		path = filepath.Join(t.callDir, path)
 	}
-	t.imports = append(t.imports, ImportToken{ImportPath: path})
+	t.imports[path] = []string{}
 }
 
 func (t *Tokenizer) skipSingleLineComment() {

--- a/lib/tokenizer/tokenizer_test.go
+++ b/lib/tokenizer/tokenizer_test.go
@@ -102,6 +102,41 @@ func TestTokenizeFile(t *testing.T) {
 	}
 }
 
+func TestTokenizeIdentifiers(t *testing.T) {
+	expected := map[string][]string{
+		"testfiles/foo":        {"default", "a", "b", "c"},
+		"testfiles/nested/bar": {"item"},
+		"testfiles/nested/baz": {"ident", "bar"},
+		"just-the-path":        {},
+	}
+	tokenizer, err := NewTokenizerFromFile("./testfiles/nested/test_idents.js")
+	if err != nil {
+		t.Fatalf("Expected successful file read. Got error: %s", err)
+	}
+	tokenizedFile := tokenizer.TokenizeImports()
+
+	if len(tokenizedFile.Imports) != len(expected) {
+		t.Fatalf("Number of imports (%d) does not match expected number (%d)", len(tokenizedFile.Imports), len(expected))
+	}
+
+	for pth, idents := range tokenizedFile.Imports {
+		expectedIdents, ok := expected[pth]
+		if !ok {
+			t.Fatalf("Received path %q which is not in imported paths", pth)
+		}
+
+		if len(idents) != len(expectedIdents) {
+			t.Fatalf("Wrong number of identifiers for path %q. Expected %d received %d", pth, len(expectedIdents), len(idents))
+		}
+
+		for i, ident := range idents {
+			if ident != expectedIdents[i] {
+				t.Errorf("Expected %q for identifier at index %d but received %q", expectedIdents[i], i, ident)
+			}
+		}
+	}
+}
+
 func TestTokenizeExports(t *testing.T) {
 	tokenizer, err := NewTokenizerFromFile("./testfiles/nested/test2.js")
 	if err != nil {

--- a/lib/tokenizer/tokenizer_test.go
+++ b/lib/tokenizer/tokenizer_test.go
@@ -6,7 +6,8 @@ import (
 
 func TestTerminates(t *testing.T) {
 	tk := New(`const foo = 5;`, "./testfiles")
-	output := tk.TokenizeImports()
+	result := tk.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 0 {
 		t.Fatalf("Should not be any import tokens")
 	}
@@ -14,7 +15,8 @@ func TestTerminates(t *testing.T) {
 
 func TestSimpleRequire(t *testing.T) {
 	tokenizer := New(`const foo = require("./foo");`, ".")
-	output := tokenizer.TokenizeImports()
+	result := tokenizer.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 1 {
 		t.Fatalf("Expected output to be length 1. Got %d", len(output))
 	}
@@ -25,7 +27,8 @@ func TestSimpleRequire(t *testing.T) {
 
 func TestImportComments(t *testing.T) {
 	tokenizer := New(`const igloo = require/* rude */  /* ugh*/( /* why */"./igloo");`, ".")
-	output := tokenizer.TokenizeImports()
+	result := tokenizer.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 1 {
 		t.Fatalf("Expected output to be length 1. Got %d", len(output))
 	}
@@ -36,7 +39,8 @@ func TestImportComments(t *testing.T) {
 
 func TestSimpleImport(t *testing.T) {
 	tokenizer := New(`import foo from "./foo";`, ".")
-	output := tokenizer.TokenizeImports()
+	result := tokenizer.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 1 {
 		t.Fatalf("Expected output to be length 1. Got %d", len(output))
 	}
@@ -47,7 +51,8 @@ func TestSimpleImport(t *testing.T) {
 
 func TestDynamicImport(t *testing.T) {
 	tokenizer := New(`const foo = await import("./foo");`, ".")
-	output := tokenizer.TokenizeImports()
+	result := tokenizer.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 1 {
 		t.Fatalf("Expected output to be length 1. Got %d", len(output))
 	}
@@ -58,7 +63,8 @@ func TestDynamicImport(t *testing.T) {
 
 func TestInvalidImport(t *testing.T) {
 	tokenizer := New(`import hello there`, ".")
-	output := tokenizer.TokenizeImports()
+	result := tokenizer.TokenizeImports()
+	output := result.ImportStrings()
 	if len(output) != 0 {
 		t.Fatalf("Expected no imports to be output. Got %s", output[0])
 	}
@@ -85,7 +91,7 @@ func TestTokenizeFile(t *testing.T) {
 		"testfiles/nested/space/bar.json",
 		"tricky",
 	}
-	for i, imp := range output {
+	for i, imp := range output.ImportStrings() {
 		if imp != expected[i] {
 			t.Errorf("Error in example %d.\n  Got: %s\n  Expected: %s", i, imp, expected[i])
 		}

--- a/lib/tokenizer/tokenizer_test.go
+++ b/lib/tokenizer/tokenizer_test.go
@@ -184,8 +184,8 @@ func TestTokenizeExports(t *testing.T) {
 
 func TestReExports(t *testing.T) {
 	expectedReExports := []string{
-		"./test",
-		"./test2",
+		"testfiles/nested/test",
+		"testfiles/nested/test2",
 	}
 
 	tokenizer, err := NewTokenizerFromFile("./testfiles/nested/index.js")


### PR DESCRIPTION
closes #1 

Changes the Tokenizer to tokenize files into file tokens with type:

```go
type FileToken struct {
	FilePath  string
	Imports   map[string][]string
	ReExports []string
	Exports   []string
}
```

The purpose of this extra information is to allow `index.js` re-exports to be properly routed to their original exporting component. To do this we need to know which identifiers are imported from a file, so that we can match them to identifiers in exporting files when re-exports take place.

Since I'm not currently trying to perform any kind of tree shaking, ReExports can always be treated as if they were:
```js
export * from './foo';
```
So we only need to track identifiers for regular exports and ES Module imports.