### PR TITLE
Export aliases

### DIFF
--- a/lib/dependencygraph/README.md
+++ b/lib/dependencygraph/README.md
@@ -61,7 +61,7 @@ import { foo } from "./foo";
 
 File extensions are not dealt with in the tokenizer because doing it there would require extra file i/o which is expensive. Since each file path is already stored with its import/export info, we have effectively already cached the relevant parts of the file system when we tokenized it. So to figure out the extension of an extensionless import we just need to check if `extensionlessImport + extension` exists in the token map. If it does, then the path will be resolved to use that extension. For imports such as named imports (e.g. `import React from 'react';`) no extension will be added.
 
-#### Create Index Maps
+#### Finish Index Maps
 
 ES Imports have a cool, but challenging to parse feature, you can import from a directory that has an `index.js` file in it:
 

--- a/lib/dependencygraph/graph_test.go
+++ b/lib/dependencygraph/graph_test.go
@@ -7,19 +7,23 @@ import (
 
 func TestParse(t *testing.T) {
 	expected_tree := map[string][]string{
-		"test_tree/a.js":                                              {"foo"},
+		"test_tree/a.js":                                              {"foo", "test_tree/re-exports/rexc.js", "test_tree/re-exports/rexb.js"},
 		"test_tree/b.ts":                                              {"foo"},
 		"test_tree/util/c.js":                                         {"lodash", "express", "test_tree/b.ts", "test_tree/util/fake_url/printFunc"},
 		"test_tree/src/components/d.jsx":                              {"react", "@remix-run/react", "test_tree/src/components/i/i.jsx"},
 		"test_tree/src/components/e.tsx":                              {},
 		"test_tree/src/components/i/i.jsx":                            {},
-		"test_tree/src/components/i/not_imported.ts":                  {},
+		"test_tree/src/components/i/not_imported.ts":                  {"test_tree/re-exports/rexa.js", "test_tree/re-exports/rexb.js"},
 		"test_tree/src/components/i/annoying.jsx":                     {"test_tree/src/components/i/i.jsx"},
 		"test_tree/src/components/i/folder/importFromParentFolder.ts": {"test_tree/src/components/i/i.jsx"},
 		"test_tree/src/components/i/index.js":                         {},
 		"test_tree/src/components/f.tsx":                              {"react", "dynamic_data"},
 		"test_tree/src/hooks/g.ts":                                    {},
 		"test_tree/src/hooks/h.ts":                                    {"test_tree/src/hooks/g.ts", "test_tree/a.js", "test_tree/src/hooks/spurious_imports.txt"},
+		"test_tree/re-exports/index.js":                               {},
+		"test_tree/re-exports/rexa.js":                                {},
+		"test_tree/re-exports/rexb.js":                                {},
+		"test_tree/re-exports/rexc.js":                                {},
 	}
 
 	dgraph := NewSync()
@@ -37,6 +41,7 @@ func TestParse(t *testing.T) {
 		}
 
 		if len(expected) != len(v) {
+			t.Log(v)
 			t.Fatalf("Wrong number of items in adjaceny list for %q. Got %d. Expected %d\n", k, len(v), len(expected))
 		}
 

--- a/lib/dependencygraph/test_tree/a.js
+++ b/lib/dependencygraph/test_tree/a.js
@@ -1,4 +1,5 @@
 import foo from "foo";
+import { rexc2, rexb } from "./re-exports";
 
 foo();
 

--- a/lib/dependencygraph/test_tree/re-exports/index.js
+++ b/lib/dependencygraph/test_tree/re-exports/index.js
@@ -1,0 +1,3 @@
+export { default as rexa } from "./rexa";
+export { default as rexb } from "./rexb";
+export * from "./rexc";

--- a/lib/dependencygraph/test_tree/re-exports/rexa.js
+++ b/lib/dependencygraph/test_tree/re-exports/rexa.js
@@ -1,0 +1,2 @@
+const rexa = "rexa";
+export default rexa;

--- a/lib/dependencygraph/test_tree/re-exports/rexb.js
+++ b/lib/dependencygraph/test_tree/re-exports/rexb.js
@@ -1,0 +1,2 @@
+const rexb = "rexb";
+export default rexb;

--- a/lib/dependencygraph/test_tree/re-exports/rexc.js
+++ b/lib/dependencygraph/test_tree/re-exports/rexc.js
@@ -1,0 +1,4 @@
+const rexc = "rexc";
+const rexc2 = "rexc2";
+
+export { rexc, rexc2 };

--- a/lib/dependencygraph/test_tree/src/components/i/not_imported.ts
+++ b/lib/dependencygraph/test_tree/src/components/i/not_imported.ts
@@ -1,3 +1,6 @@
+import { rexa } from "../../../re-exports";
+import defaultImport from "../../../re-exports/rexb";
+
 export const veggies = [
   "kale",
   "sweet potatoes",

--- a/lib/tokenizer/testfiles/nested/test2.js
+++ b/lib/tokenizer/testfiles/nested/test2.js
@@ -2,8 +2,8 @@ import defaultExample, { example } from "example";
 
 const foo = "foo";
 const bar = "bar";
-const baz = "baz";
+const aliased = "baz";
 
 export const five = 5;
-export { foo, bar, baz };
+export { foo, bar, aliased as baz };
 export default function noop() {}

--- a/lib/tokenizer/testfiles/nested/test2.js
+++ b/lib/tokenizer/testfiles/nested/test2.js
@@ -3,7 +3,8 @@ import defaultExample, { example } from "example";
 const foo = "foo";
 const bar = "bar";
 const aliased = "baz";
+export const x = "x";
 
 export const five = 5;
-export { foo, bar, aliased as baz };
+export { foo as pressF, bar, aliased as baz };
 export default function noop() {}

--- a/lib/tokenizer/tokenizer_test.go
+++ b/lib/tokenizer/tokenizer_test.go
@@ -144,8 +144,9 @@ func TestTokenizeExports(t *testing.T) {
 	}
 
 	expectedExports := []string{
+		"x",
 		"five",
-		"foo",
+		"pressF",
 		"bar",
 		"baz",
 		"default",
@@ -188,6 +189,11 @@ func TestReExports(t *testing.T) {
 		"testfiles/nested/test2",
 	}
 
+	expectedReExportMap := map[string]string{
+		"func":                   "testfiles/nested/test",
+		"testfiles/nested/test2": "*",
+	}
+
 	tokenizer, err := NewTokenizerFromFile("./testfiles/nested/index.js")
 	if err != nil {
 		t.Fatalf("Expected successful file read. Got error: %s", err)
@@ -202,6 +208,20 @@ func TestReExports(t *testing.T) {
 	for i, rex := range tokenizedFile.ReExports {
 		if rex != expectedReExports[i] {
 			t.Errorf("Expected re-export at index %d to be %q but received %q", i, expectedReExports[i], rex)
+		}
+	}
+
+	if len(tokenizedFile.ReExportMap) != len(expectedReExportMap) {
+		t.Log(tokenizedFile.ReExportMap)
+		t.Fatalf("Expected %d entries in the re-export map but received %d", len(expectedReExportMap), len(tokenizedFile.ReExportMap))
+	}
+	for k, v := range tokenizedFile.ReExportMap {
+		expectedValue, keyExists := expectedReExportMap[k]
+		if !keyExists {
+			t.Fatalf("Received unexpected key %q from reExportMap", k)
+		}
+		if expectedValue != v {
+			t.Errorf("Received wrong value for key %q. Expected %q received %q", k, expectedValue, v)
 		}
 	}
 }


### PR DESCRIPTION
closes #7 

# Changes
- Handles most of populating the reExportMap inside of tokenizer
- Fixes bug where export aliases are skipped
- Adds test cases for reExport aliases
- Adds test cases for export aliases