### PR TITLE
Typescript tokens

### DIFF
--- a/lib/tokenizer/testfiles/nested/test2.ts
+++ b/lib/tokenizer/testfiles/nested/test2.ts
@@ -1,7 +1,9 @@
 // @ts-ignore
 import defaultExample, { example } from "example";
 // @ts-ignore
-import type { FooType } from "@types/foo";
+import type { FooType } from "@Foo/foo";
+// @ts-ignore
+import { Foo } from "@Foo/foo";
 
 const foo = "foo";
 const bar = "bar";

--- a/lib/tokenizer/testfiles/nested/test2.ts
+++ b/lib/tokenizer/testfiles/nested/test2.ts
@@ -1,4 +1,7 @@
+// @ts-ignore
 import defaultExample, { example } from "example";
+// @ts-ignore
+import type { FooType } from "@types/foo";
 
 const foo = "foo";
 const bar = "bar";
@@ -7,4 +10,10 @@ export const x = "x";
 
 export const five = 5;
 export { foo as pressF, bar, aliased as baz };
+export type Noop = () => void;
+export interface IStuff {
+  thing: object;
+  item: object;
+}
+
 export default function noop() {}

--- a/lib/tokenizer/tokenizer.go
+++ b/lib/tokenizer/tokenizer.go
@@ -138,6 +138,11 @@ func (t *Tokenizer) tokenizeImport() {
 		return
 	}
 
+	if _, exists := t.imports[importPath]; exists {
+		t.imports[importPath] = append(t.imports[importPath], identifiers...)
+		return
+	}
+
 	t.imports[importPath] = identifiers
 }
 

--- a/lib/tokenizer/tokenizer_test.go
+++ b/lib/tokenizer/tokenizer_test.go
@@ -144,8 +144,8 @@ func TestImportTypes(t *testing.T) {
 	}
 
 	expected := map[string][]string{
-		"example":    {"default", "example"},
-		"@types/foo": {"FooType"},
+		"example":  {"default", "example"},
+		"@Foo/foo": {"FooType", "Foo"},
 	}
 
 	tokenizedFile := tokenizer.Tokenize()


### PR DESCRIPTION
closes #9 

# Changes
- Ignore `type` and `interface` keywords when exporting
- Use `{` as a stop character when exporting interfaces
- Ignore `type` keyword when importing
- Append identifiers when an import path already exists instead of overwriting previous identifiers