### PR TITLE
support path aliases in config

### DIFF
--- a/lib/dependencygraph/README.md
+++ b/lib/dependencygraph/README.md
@@ -61,6 +61,8 @@ import { foo } from "./foo";
 
 File extensions are not dealt with in the tokenizer because doing it there would require extra file i/o which is expensive. Since each file path is already stored with its import/export info, we have effectively already cached the relevant parts of the file system when we tokenized it. So to figure out the extension of an extensionless import we just need to check if `extensionlessImport + extension` exists in the token map. If it does, then the path will be resolved to use that extension. For imports such as named imports (e.g. `import React from 'react';`) no extension will be added.
 
+Import aliases are also handled here. These could potentially be handled in the tokenizer in the future, but were more convenient to handle at parse time with how things are currently structured.
+
 #### Finish Index Maps
 
 ES Imports have a cool, but challenging to parse feature, you can import from a directory that has an `index.js` file in it:

--- a/lib/dependencygraph/dependor.json
+++ b/lib/dependencygraph/dependor.json
@@ -1,3 +1,6 @@
 {
-  "ignorePatterns": ["**/node_modules"]
+  "ignorePatterns": ["**/node_modules"],
+  "pathAliases": {
+    "~": "test_tree"
+  }
 }

--- a/lib/dependencygraph/graph_test.go
+++ b/lib/dependencygraph/graph_test.go
@@ -10,7 +10,7 @@ func TestParse(t *testing.T) {
 		"test_tree/a.js":                                              {"foo", "test_tree/re-exports/rexc.js", "test_tree/re-exports/rexb.js"},
 		"test_tree/b.ts":                                              {"foo"},
 		"test_tree/util/c.js":                                         {"lodash", "express", "test_tree/b.ts", "test_tree/util/fake_url/printFunc"},
-		"test_tree/src/components/d.jsx":                              {"react", "@remix-run/react", "test_tree/src/components/i/i.jsx"},
+		"test_tree/src/components/d.jsx":                              {"react", "@remix-run/react", "test_tree/src/components/i/i.jsx", "test_tree/a.js"},
 		"test_tree/src/components/e.tsx":                              {},
 		"test_tree/src/components/i/i.jsx":                            {},
 		"test_tree/src/components/i/not_imported.ts":                  {"test_tree/re-exports/rexa.js", "test_tree/re-exports/rexb.js"},

--- a/lib/dependencygraph/test_tree/src/components/d.jsx
+++ b/lib/dependencygraph/test_tree/src/components/d.jsx
@@ -5,6 +5,7 @@ import {
   useSearchParams,
 } from '@remix-run/react';
 import { IComponent } from './i';
+import foo from '~/a';
 
 export const Component = () => (
   <Import>


### PR DESCRIPTION
Config files allowed for path aliases to be set but alias replacement was not implemented in dependency graph parsing. This change implements that.