### PR TITLE
change directory to `rootPath` when provided

### DIFF
--- a/graphParserSync.go
+++ b/graphParserSync.go
@@ -27,12 +27,13 @@ func NewSync(rootPath ...string) *SingleThreadedGraphParser {
 	if len(rootPath) > 0 {
 		rp = rootPath[0]
 	}
-	configPath := rp + "/dependor.json"
-	if _, err := os.Stat(configPath); rp != "." && err != nil {
-		panic(fmt.Sprintf("Root path does not exist or does not have a valid dependor.json config file. To use default config, omit rootPath arg. See error %s\n", err))
+
+	err := os.Chdir(rp)
+	if err != nil {
+		panic(fmt.Sprintf("Root path does not exist. See error %s\n", err))
 	}
 
-	cfg, err := config.ReadConfig(rp + "/dependor.json")
+	cfg, err := config.ReadConfig("dependor.json")
 	if err != nil {
 		fmt.Println("WARN: No dependor.json file was found so the default config is being used.")
 	}


### PR DESCRIPTION
closes #24 

# Changes
- instead of prefixing paths with `rootPath` in walks, change the directory to `rootPath`
- this should make ignorePatterns more reliable
