### PR TITLE
Fix handling of exported classes and interfaces

### DIFF
--- a/graphParserSync_test.go
+++ b/graphParserSync_test.go
@@ -25,6 +25,7 @@ func TestParse(t *testing.T) {
 		"test_tree/re-exports/rexa.js":                                {},
 		"test_tree/re-exports/rexb.js":                                {},
 		"test_tree/re-exports/rexc.js":                                {},
+		"test_tree/type-edge-cases.ts":                                {},
 	}
 
 	dgraph := NewSync()

--- a/internal/tokenizer/testfiles/interfaces-and-classes.ts
+++ b/internal/tokenizer/testfiles/interfaces-and-classes.ts
@@ -1,0 +1,43 @@
+interface Foo {
+  bar: string;
+  baz: number;
+}
+
+export interface Extender extends Pick<Foo, 'baz'> {
+  extension: 'ts';
+}
+
+export class Basic {
+  constructor() {
+
+  }
+
+  hello() {
+    console.log('hello!');
+  }
+}
+
+// TODO: Handle generic types
+// export class Stack<T> {
+//   private _stack: T[]
+//   constructor(init?: T[]) {
+//     this._stack = init ?? [];
+//   }
+
+//   push(key: T) {
+//     this._stack.push(key);
+//     return this._stack.length;
+//   }
+
+//   pop() {
+//     return this._stack.pop();
+//   }
+
+//   top() {
+//     return this._stack[this._stack.length - 1];
+//   }
+
+//   size() {
+//     return this._stack.length;
+//   }
+// }

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -86,10 +86,10 @@ func (t *Tokenizer) readExport() {
 	var identifiers []string
 	isReExport := false
 	haveSeenLeftBrace := false
-	// interface declarations can extend other interfaces
-	// to deal with the this we need to return immediately
-	// after encountering the next identifier
-	haveSeenInterface := false
+	// classes and interfaces should always export the next identifier
+	// we could also look for end chars ('{' and 'extends' in this case)
+	// but this seems like a better way to avoid potential edge cases
+	haveSeenInterfaceOrClass := false
 	// '}' is also sort of an an endChar. e.g. export { foo, bar } w/o semi-colon
 	// but it's ambiguous because for re-exports we'd need to continue. I'm not sure
 	// there's any way to handle this case besides looking ahead afterwards
@@ -131,16 +131,16 @@ Loop:
 			case "from":
 				isReExport = true
 				break Loop
-			case "interface":
-				haveSeenInterface = true
-			case "const", "let", "var", "function", "function*", "class", "type":
+			case "interface", "class":
+				haveSeenInterfaceOrClass = true
+			case "const", "let", "var", "function", "function*", "type":
 				continue
 			default:
 				if ident == "default" && !haveSeenLeftBrace {
 					identifiers = append(identifiers, ident)
 					break Loop
 				}
-				if haveSeenInterface {
+				if haveSeenInterfaceOrClass {
 					identifiers = append(identifiers, ident)
 					break Loop
 				}

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -307,6 +307,21 @@ func TestMdnExports(t *testing.T) {
 	testArray(t, tokenizedFile.Exports, expectedExports)
 }
 
+func TestInterfacesAndClasses(t *testing.T) {
+	expectedExports := []string{
+		"Extender",
+		"Basic",
+		// TODO: Handle generics
+		// "Stack",
+	}
+	tokenizer, err := NewTokenizerFromFile("./testfiles/interfaces-and-classes.ts")
+	if err != nil {
+		t.Fatalf("Expected successful file read. Got error: %s", err)
+	}
+	tokenizedFile := tokenizer.Tokenize()
+	testArray(t, tokenizedFile.Exports, expectedExports)
+}
+
 func testEdgeList(t *testing.T, edgeList, expected map[string][]string) {
 	if len(edgeList) != len(expected) {
 		t.Errorf("Expected edge list to have length %d but receive %d", len(expected), len(edgeList))

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -79,6 +79,12 @@ func TestNonTerminatingImport(t *testing.T) {
 	tokenizer.Tokenize()
 }
 
+func TestInterfaceExport(t *testing.T) {
+	tokenizer := New(`export interface EdgeCase extends Pick<Foo, 'bar' | 'baz'> {};`, "*")
+	tokenizedFile := tokenizer.Tokenize()
+	testArray(t, tokenizedFile.Exports, []string{"EdgeCase"})
+}
+
 func TestTokenizeFile(t *testing.T) {
 	tokenizer, err := NewTokenizerFromFile("./testfiles/nested/test.js")
 	if err != nil {

--- a/test_tree/type-edge-cases.ts
+++ b/test_tree/type-edge-cases.ts
@@ -1,0 +1,11 @@
+interface EdgeCase {
+  foo: string;
+  bar: number;
+  baz: boolean;
+}
+
+export interface UtilityInterface extends Pick<EdgeCase, 'foo' | 'baz'> {
+  utils: number;
+};
+
+export type UtilityType = Omit<EdgeCase, 'foo'>;


### PR DESCRIPTION
Closes #28 

**Notes**
- Found #29 while addressing this issue
- Does NOT handle #29 
- Stops tokenizing exported classes and identifiers on the next identifier instead of using '{' as a stop char