### PR TITLE
fix: support generics and type annotations in exports

### DIFF
--- a/internal/tokenizer/testfiles/interfaces-and-classes.ts
+++ b/internal/tokenizer/testfiles/interfaces-and-classes.ts
@@ -17,27 +17,36 @@ export class Basic {
   }
 }
 
-// TODO: Handle generic types
-// export class Stack<T> {
-//   private _stack: T[]
-//   constructor(init?: T[]) {
-//     this._stack = init ?? [];
-//   }
+export class Advanced extends Basic {
+  constructor() {
+    super();
+  }
 
-//   push(key: T) {
-//     this._stack.push(key);
-//     return this._stack.length;
-//   }
+  helloAgain() {
+    console.log('hello again?');
+  }
+}
 
-//   pop() {
-//     return this._stack.pop();
-//   }
+export class Stack<T> {
+  private _stack: T[]
+  constructor(init?: T[]) {
+    this._stack = init ?? [];
+  }
 
-//   top() {
-//     return this._stack[this._stack.length - 1];
-//   }
+  push(key: T) {
+    this._stack.push(key);
+    return this._stack.length;
+  }
 
-//   size() {
-//     return this._stack.length;
-//   }
-// }
+  pop() {
+    return this._stack.pop();
+  }
+
+  top() {
+    return this._stack[this._stack.length - 1];
+  }
+
+  size() {
+    return this._stack.length;
+  }
+}

--- a/internal/tokenizer/testfiles/types.tsx
+++ b/internal/tokenizer/testfiles/types.tsx
@@ -3,14 +3,26 @@ export const foo: string = 'a string';
 
 interface MyComponentProps {
   className?: string;
+  paragraphContents?: string;
+  '>': 'why' | 'would' | 'you' | 'do' | 'this?'
 }
 // generics
 export const MyComponent: React.FC<MyComponentProps> = (props) => {
   return (
-    <div className={props.className}>
-      component
-    </div>
+    <p className={props.className}>
+      {props.paragraphContents}
+    </p>
   )
+}
+
+// nested generic case
+export const NestedGeneric: React.FC<Pick<MyComponentProps, 'className'>> = (props) => {
+  return <div className={props.className} />
+}
+
+// all the things at once
+export const Brutal: React.FC</* > */Omit</* < */MyComponentProps, '>'>> = (props) => {
+  return <p>rude</p>;
 }
 
 // generic with interface

--- a/internal/tokenizer/testfiles/types.tsx
+++ b/internal/tokenizer/testfiles/types.tsx
@@ -1,0 +1,56 @@
+// explicit type annotations
+export const foo: string = 'a string';
+
+interface MyComponentProps {
+  className?: string;
+}
+// generics
+export const MyComponent: React.FC<MyComponentProps> = (props) => {
+  return (
+    <div className={props.className}>
+      component
+    </div>
+  )
+}
+
+// generic with interface
+export interface LinkedListNode<T> {
+  key: T;
+  next?: LinkedListNode<T>;
+}
+// generic in class
+class LinkedList<T> {
+  private head: LinkedListNode<T> | null = null;
+  private length: number = 0;
+
+  constructor(initList?: T[]) {
+    if (initList && initList.length > 0) {
+      initList.forEach((key) => this.add(key));
+    }
+  }
+
+  add(key: T) {
+    if (this.head === null) {
+      this.head = { key };
+      this.length++;
+      return;
+    }
+    let current = this.head;
+    while (current.next) {
+      current = current.next;
+    }
+    current.next = { key };
+    this.length++;
+  }
+
+  find(key: T) {
+    let current: LinkedListNode<T> | null | undefined = this.head;
+    while (current) {
+      if (current.key === key) {
+        return current;
+      }
+      current = current.next;
+    }
+    return null;
+  }
+}

--- a/internal/tokenizer/testfiles/types.tsx
+++ b/internal/tokenizer/testfiles/types.tsx
@@ -31,7 +31,7 @@ export interface LinkedListNode<T> {
   next?: LinkedListNode<T>;
 }
 // generic in class
-class LinkedList<T> {
+export class LinkedList<T> {
   private head: LinkedListNode<T> | null = null;
   private length: number = 0;
 

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -96,7 +96,7 @@ func (t *Tokenizer) readExport() {
 	endedOnBrace := false
 	// overwrite exported identifiers with their aliases so that they are correctly mapped to importing files
 	overwriteLastIdentifier := false
-	endChars := []rune{';', '(', '='}
+	endChars := []rune{';', '(', '=', '<'}
 
 Loop:
 	for t.char != 0 {
@@ -335,11 +335,6 @@ func (t *Tokenizer) skipMultiLineComment() {
 	}
 	t.readChar()
 	t.readChar()
-}
-
-// e.g. React.FC<Pick<x, 'y' | 'z'>>
-func (t *Tokenizer) skipGenericTypeArgument() {
-
 }
 
 func (t *Tokenizer) readIdentifier() string {

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -108,6 +108,11 @@ Loop:
 			haveSeenLeftBrace = true
 			t.readChar()
 		case t.char == ':':
+			if !haveSeenLeftBrace {
+				// outside of braces this is a type annotation
+				break Loop
+			}
+			// inside of braces this is an alias
 			overwriteLastIdentifier = true
 			t.readChar()
 		case t.char == '/':
@@ -330,6 +335,11 @@ func (t *Tokenizer) skipMultiLineComment() {
 	}
 	t.readChar()
 	t.readChar()
+}
+
+// e.g. React.FC<Pick<x, 'y' | 'z'>>
+func (t *Tokenizer) skipGenericTypeArgument() {
+
 }
 
 func (t *Tokenizer) readIdentifier() string {

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -311,10 +311,25 @@ func TestInterfacesAndClasses(t *testing.T) {
 	expectedExports := []string{
 		"Extender",
 		"Basic",
-		// TODO: Handle generics
-		// "Stack",
+		"Advanced",
+		"Stack",
 	}
 	tokenizer, err := NewTokenizerFromFile("./testfiles/interfaces-and-classes.ts")
+	if err != nil {
+		t.Fatalf("Expected successful file read. Got error: %s", err)
+	}
+	tokenizedFile := tokenizer.Tokenize()
+	testArray(t, tokenizedFile.Exports, expectedExports)
+}
+
+func TestTypes(t *testing.T) {
+	expectedExports := []string{
+		"foo",
+		"MyComponent",
+		"LinkedListNode",
+		"LinkedList",
+	}
+	tokenizer, err := NewTokenizerFromFile("./testfiles/types.tsx")
 	if err != nil {
 		t.Fatalf("Expected successful file read. Got error: %s", err)
 	}

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -326,6 +326,8 @@ func TestTypes(t *testing.T) {
 	expectedExports := []string{
 		"foo",
 		"MyComponent",
+		"NestedGeneric",
+		"Brutal",
 		"LinkedListNode",
 		"LinkedList",
 	}

--- a/internal/tokenizer/utils.go
+++ b/internal/tokenizer/utils.go
@@ -30,6 +30,8 @@ var identifier_ends = []rune{
 	'[',
 	']',
 	':',
+	// Note: this can happen in generic types e.g. export class LinkedList<T>
+	'<',
 }
 
 func isIdentifierEnd(char rune) bool {


### PR DESCRIPTION
closes #29 

This turned out to be simpler than I thought. Hopefully it was.

- treats '<' as a stop character in `Tokenizer.readIdentifier`
- treats '<' as a stop character in 'Tokenizer.readExport`
- ends `Tokenizer.readExport` early when ':' is found and `haveSeenLeftBrace` is false
- Adds several tests for these cases