### PR TITLE
fix: skip code in strings

### DIFF
--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -372,8 +372,8 @@ func (t *Tokenizer) readPathString() string {
 	return pathString
 }
 
-// need to skip strings to avoid reading code inside of strings as real strings
-// this needs to be a recursive process because a string can be nested inside
+// need to skip strings to avoid treating code inside of strings as real code.
+// This needs to be a recursive process because a string can be nested inside
 // of a string. We also need to handle escaped strings
 func (t *Tokenizer) skipString(startChar rune) {
 	t.readChar()

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -57,6 +57,15 @@ func TestSimpleImport(t *testing.T) {
 	}
 }
 
+func TestSkipString(t *testing.T) {
+	tokenizer := New(`"import foo from './foo';"`, ".")
+	tokenizedFile := tokenizer.Tokenize()
+	output := getImportStrings(tokenizedFile)
+	if len(output) != 0 {
+		t.Fatalf("Expected not to read any imports but got %d", len(output))
+	}
+}
+
 func TestDynamicImport(t *testing.T) {
 	tokenizer := New(`const foo = await import("./foo"); "bar";`, ".")
 	tokenizedFile := tokenizer.Tokenize()
@@ -324,6 +333,7 @@ func TestTypes(t *testing.T) {
 
 func TestEdgeCases(t *testing.T) {
 	expectedExports := []string{
+		"imports",
 		"exports",
 	}
 	testFileExports(t, "./testfiles/edge-cases.tsx", expectedExports)

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -66,6 +66,15 @@ func TestSkipString(t *testing.T) {
 	}
 }
 
+func TestSkipStringWithEscapedQuote(t *testing.T) {
+	tokenizer := New(`" \" import foo from './foo';"`, ".")
+	tokenizedFile := tokenizer.Tokenize()
+	output := getImportStrings(tokenizedFile)
+	if len(output) != 0 {
+		t.Fatalf("Expected not to read any imports but got %d", len(output))
+	}
+}
+
 func TestDynamicImport(t *testing.T) {
 	tokenizer := New(`const foo = await import("./foo"); "bar";`, ".")
 	tokenizedFile := tokenizer.Tokenize()


### PR DESCRIPTION
closes #32 

- Adds a `skipString` helper to `tokenizer`
- Calls `skipString` when encountering quotes at the top level