### PR TITLE
add test for destructured types

### DIFF
--- a/internal/tokenizer/testfiles/nested/test2.ts
+++ b/internal/tokenizer/testfiles/nested/test2.ts
@@ -4,6 +4,8 @@ import defaultExample, { example } from "example";
 import type { FooType } from "@Foo/foo";
 // @ts-ignore
 import { Foo } from "@Foo/foo";
+// @ts-ignore
+import { Bar, type BarType } from "@Bar/bar";
 
 const foo = "foo";
 const bar = "bar";

--- a/internal/tokenizer/tokenizer_test.go
+++ b/internal/tokenizer/tokenizer_test.go
@@ -182,6 +182,7 @@ func TestImportTypes(t *testing.T) {
 	expected := map[string][]string{
 		"example":  {"default", "example"},
 		"@Foo/foo": {"FooType", "Foo"},
+		"@Bar/bar": {"Bar", "BarType"},
 	}
 
 	tokenizedFile := tokenizer.Tokenize()


### PR DESCRIPTION
closes #34 

It turns out that the code I wrote to handle type imports like this:

```ts
import type { ButtonProps } from '~/components/button';
```

Already also works for mixed type / non-type imports like this:

```ts
import { Button, type ButtonProps } from '~/components/button';
```

But it was still worth explicitly testing for this since it's part of the spec.